### PR TITLE
AB#131136 Add Buttons and Messages to Blueprint

### DIFF
--- a/Library/Models/CopyableSurveyConfiguration.cs
+++ b/Library/Models/CopyableSurveyConfiguration.cs
@@ -27,5 +27,6 @@ namespace Nfield.Models
 
         QuotaFrame = 1,
         QuestionnaireScript = 2,
+        TranslationLanguages = 4, // this is called "buttons and messages" in the UI
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.64.{buildId}{suffix}
+2.65.{buildId}{suffix}

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.63.{buildId}{suffix}
+2.64.{buildId}{suffix}


### PR DESCRIPTION
This story brings: "blueprints now support questionnaire scripts, so we should also support buttons and messages as they are also part of the questionnaire."

The story on our board: [AB#131136](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/131136) 

Tests run:

- [x] Nfield Manager webdriver tests

All PRs:

- https://github.com/NIPOSoftwareBV/project-glu-client/pull/6250
- https://github.com/NIPOSoftwareBV/project-glu-api/pull/5470
- https://github.com/NIPOSoftwareBV/Nfield-SDK/pull/450
- https://github.com/NIPOSoftwareBV/nfield-source/pull/8579
