### PR TITLE
GitHub service connection

### DIFF
--- a/Pipelines/build.yml
+++ b/Pipelines/build.yml
@@ -25,7 +25,7 @@ resources:
     - repository: NfieldTools
       type: github
       name: NIPOSoftwareBV/Nfield-Tools
-      endpoint: NfieldToolsRepository
+      endpoint: Nfield # DevOps Service Connection
       ref: # Defaults to master, to build with another version specify the ref here (e.g. 'refs/tags/2019-q1s01') If you want to build from a specific commit, first create a tag pointing to that commit, then pin to that tag.
 
 

--- a/Pipelines/deploy-nuget.yml
+++ b/Pipelines/deploy-nuget.yml
@@ -23,13 +23,11 @@ resources:
     - repository: NfieldTools
       type: github
       name: NIPOSoftwareBV/Nfield-Tools
-      endpoint: NfieldToolsRepository
+      endpoint: Nfield # DevOps Service Connection
       ref: # Defaults to master, to build with another version specify the ref here (e.g. 'refs/tags/2019-q1s01') If you want to build from a specific commit, first create a tag pointing to that commit, then pin to that tag.
-
 
 pool:
   vmImage: windows-2022
-
 
 stages:
 - template: AzureDevOps/SDK-and-Quota-pipelines/deploy-sdk-nuget.yml@NfieldTools 


### PR DESCRIPTION
[AB#132060](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/132060)

**Related PRs:**
https://github.com/NIPOSoftwareBV/nfield-source/pull/8602
https://github.com/NIPOSoftwareBV/Nfield.Quota/pull/121
https://github.com/NIPOSoftwareBV/Nfield-Tools/pull/1167
https://github.com/NIPOSoftwareBV/nfield-public-api/pull/169


**To change:**
Use always Nfield a GitHub-InstallationToken
NfieldToolsRepository to Nfield to be aligned with the pipeline triggers that are using Nfield, NfieldToolsRepository is not needed anymore

**New for specific cases:**
NipoGithubDeployment PAT to be used by DevOps GitHub[...]@1 tasks that only allow oauth and PAT Service Connections. This Github PAT has been created with the shared account nipodeployment@ktglbuc.onmicrosoft.com (See Nfield Passwords - powerful accounts.kdbx)

**Next PBI:**
[Cleanup](https://dev.azure.com/niposoftware/Nfield/_backlogs/backlog/Team%20Yellow/Features/?workitem=133929)

Service connections
|Creator							|Email							|Service connection Name	| Type - User									|
|-									|-								|-							| -   											|
|Pilar Rodriguez Cabrero			|p.rodriguez.cabrero@nipo.com	|NfieldToolsRepository		|oauth - unknown								|
|									|								|pilarodriguez				|oauth - unknown								|
|									|								|test						|oauth - unknown								|
|									|p.rodriguez.cabrero@kantar.com	|github.com_sdk				|oauth - unknown								|
|Eva del Nuevo						|e.del.nuevo.munoz@nipo.com		|niposoftware-github		|oauth - unknown								|
|									|								|GitHub connection 1		|oauth - unknown								|
|Jouke van der Maas					|j.maas@nipo.com				|github.com_hnuguse			|oauth - User unknown							|
|									|j.maas@kantar.com				|Nfield						|azure pipelines app							|
|Henok Nuguse						|h.nuguse@nipo.com				|Nfield						|azure pipelines app							|
|									|								|hnuguse					|oauth - unknown								|
|k.efishev							|k.efishev@kantar.com			|kefishev					|oauth - unknown								|
|Neil Boyd							|n.boyd@kantar.com				|GitHub connection 17		|oauth - unknown								|
|									|n.boyd@niposoftware.com		|github.com_nipodeployment	|oauth - unknown								|
|Daniel Quilón						|d.quilon@kantar.com			|Nfield (1)					|azure pipelines app							|
|g.kappen							|g.kappen@niposoftware.com		|GitHub as gkappen			|oauth - unknown								|
|h.kraakman							|h.kraakman@niposoftware.com	|GitHub connection HK		|PAT - unknown									|
|Alberto.Belver						|Alberto.Belver@kantar.com		|github.com_AlbertoBelver	|oauth - unknown								|
|Alberto.Belver						|Alberto.Belver@kantar.com		|NipoGithubDeployment	    |PAT - nipodeployment@ktglbuc.onmicrosoft.com	|


Service connections usage
|Service connection Name	| Used in NIPOSoftwareBV code	| Used in DevOps Trigges			|
|-							|-       						|-									|
|NfieldToolsRepository		| Many pipelines  				|?									|
|pilarodriguez				| No							|?									|
|test						| N/A 							|?									|
|github.com_sdk				| No							|?									|
|niposoftware-github		| No							|?									|
|GitHub connection 1		| No							|?									|
|github.com_hnuguse			| No							|?									|
|Nfield						| Not in pipelines				|Yes but we don't know witch Nfield	|
|Nfield						| Not in pipelines				|Yes but we don't know witch Nfield	|
|hnuguse					| No							|?									|
|kefishev					| No							|?									|
|GitHub connection 17		| No							|?									|
|github.com_nipodeployment	| No							|?									|
|Nfield (1)					| No							|?									|
|GitHub as gkappen			| No							|?									|
|GitHub connection HK		| No							|?									|
|github.com_AlbertoBelver	| No							|?									|
|NipoGithubDeployment	    | SDK and Quota pipelines		|?									|

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-yellow