### PR TITLE
Purple/get single samplerecord

### DIFF
--- a/Library/Services/INfieldSurveySampleService.cs
+++ b/Library/Services/INfieldSurveySampleService.cs
@@ -26,13 +26,23 @@ namespace Nfield.Services
     public interface INfieldSurveySampleService
     {
         /// <summary>
-        /// start task to download sample
+        /// get sample records for survey
         /// </summary>
         /// <param name="surveyId">The id of the survey</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        /// <returns>task</returns>
+        /// <returns>content of csv file containing a data records + header</returns>
         Task<string> GetAsync(string surveyId);
+
+        /// <summary>
+        /// get single sample record for survey
+        /// </summary>
+        /// <param name="surveyId">The id of the survey</param>
+        /// <param name="interviewId">The id (interview number) of the sample record</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        /// <returns>content of csv file containing a single data record + header</returns>
+        Task<string> GetSingleSampleRecordAsync(string surveyId, int interviewId);
 
         /// <summary>
         /// upload csv sample

--- a/Library/Services/INfieldSurveySampleService.cs
+++ b/Library/Services/INfieldSurveySampleService.cs
@@ -31,7 +31,7 @@ namespace Nfield.Services
         /// <param name="surveyId">The id of the survey</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        /// <returns>content of csv file containing a data records + header</returns>
+        /// <returns>content of csv file containing all data records + header</returns>
         Task<string> GetAsync(string surveyId);
 
         /// <summary>

--- a/Library/Services/Implementation/NfieldSurveySampleService.cs
+++ b/Library/Services/Implementation/NfieldSurveySampleService.cs
@@ -43,6 +43,16 @@ namespace Nfield.Services.Implementation
                 .FlattenExceptions();
         }
 
+        public async Task<string> GetSingleSampleRecordAsync(string surveyId, int interviewId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/Sample/{interviewId}");
+
+            var response = await Client.GetAsync(uri);
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public Task<SampleUploadStatus> PostAsync(string surveyId, string sample)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));

--- a/Tests/Services/NfieldSurveySampleTests.cs
+++ b/Tests/Services/NfieldSurveySampleTests.cs
@@ -82,6 +82,38 @@ namespace Nfield.Services
 
         #endregion
 
+        #region GetSingleSampleRecordAsync
+
+        [Fact]
+        public void TestGetSingleSampleRecordAsync_SurveyIdIsNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                UnwrapAggregateException(_target.GetSingleSampleRecordAsync(null, 0)));
+        }
+
+        [Fact]
+        public void TestGetSingleSampleRecordAsync_SurveyIdIsEmpty_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                UnwrapAggregateException(_target.GetSingleSampleRecordAsync("  ", 0)));
+        }
+
+        [Fact]
+        public void TestGetSingleSampleRecordAsync_SurveyHasSample_ReturnsSample()
+        {
+            const string sample = "a sample";
+            var content = new StringContent(sample);
+            _mockedHttpClient
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + SurveyId + "/Sample/1")))
+                .Returns(CreateTask(HttpStatusCode.OK, content));
+
+            var actual = _target.GetSingleSampleRecordAsync(SurveyId, 1).Result;
+
+            Assert.Equal(sample, actual);
+        }
+
+        #endregion
+
         #region SendInvitationsAsync
 
         [Fact]

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.70.{buildId}{suffix}
+2.71.{buildId}{suffix}


### PR DESCRIPTION
[AB#141129](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/141129)

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-blue