### PR TITLE
Public api cleanup:

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -54,6 +54,7 @@ namespace Nfield.Infrastructure
             { typeof(INfieldSurveyEmailSettingsService), typeof(NfieldSurveyEmailSettingsService) },
             { typeof(INfieldSurveyInvitationImagesService), typeof(NfieldSurveyInvitationImagesService) },
             { typeof(INfieldSurveyInvitationTemplatesService), typeof(NfieldSurveyInvitationTemplatesService) },
+            { typeof(INfieldSamplingPointsQuotaTargetsService), typeof(NfieldSamplingPointsQuotaTargetsService) },
             { typeof(INfieldSurveyQuotaFrameService), typeof(NfieldSurveyQuotaFrameService) },
             { typeof(INfieldSurveySettingsService), typeof(NfieldSurveySettingsService) },
             { typeof(INfieldSurveyInterviewInteractionsSettingsService), typeof(NfieldSurveyInterviewInteractionsSettingsService) },

--- a/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
@@ -22,7 +22,7 @@ namespace Nfield.SDK.Services
     public interface INfieldSamplingPointsQuotaTargetsService
     {
         Task<SamplingPointQuotaTarget> GetAsync(string surveyId, string samplingPointId, string quotaLevelId);
-        Task<IQueryable<SamplingPointQuotaTarget>> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target);
         Task<IQueryable<SamplingPointQuotaTarget>> QueryAsync(string surveyId, string samplingPointId);
+        Task<SamplingPointQuotaTarget> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target);
     }
 }

--- a/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
@@ -1,0 +1,28 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nfield.SDK.Services
+{
+    public interface INfieldSamplingPointsQuotaTargetsService
+    {
+        Task<SamplingPointQuotaTarget> GetAsync(string surveyId, string samplingPointId, string quotaLevelId);
+        Task<IQueryable<SamplingPointQuotaTarget>> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target);
+        Task<IQueryable<SamplingPointQuotaTarget>> QueryAsync(string surveyId, string samplingPointId);
+    }
+}

--- a/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/INfieldSamplingPointsQuotaTargetsService.cs
@@ -19,10 +19,35 @@ using System.Threading.Tasks;
 
 namespace Nfield.SDK.Services
 {
+    /// <summary>
+    /// Represents a set of methods to read and update the sampling points quota targets.
+    /// </summary>
     public interface INfieldSamplingPointsQuotaTargetsService
     {
+        /// <summary>
+        /// Gets the quota level targets of the specified sampling point
+        /// </summary>
+        /// <param name="surveyId">The survey id</param>
+        /// <param name="samplingPointId">The sampling point id</param>
+        /// <param name="quotaLevelId">The quota level id</param>
         Task<SamplingPointQuotaTarget> GetAsync(string surveyId, string samplingPointId, string quotaLevelId);
+
+        /// <summary>
+        /// Gets the quota targets of the specified sampling point
+        /// </summary>
+        /// <param name="surveyId">The survey id</param>
+        /// <param name="samplingPointId">The sampling point id</param>
+        /// <returns></returns>
         Task<IQueryable<SamplingPointQuotaTarget>> QueryAsync(string surveyId, string samplingPointId);
+
+        /// <summary>
+        /// Updates the quota level target of the specified sampling point
+        /// </summary>
+        /// <param name="surveyId">The survey id</param>
+        /// <param name="samplingPointId">The sampling point id</param>
+        /// <param name="quotaLevelId">The quota level id</param>
+        /// <param name="target">The new quota level target value</param>
+        /// <returns></returns>
         Task<SamplingPointQuotaTarget> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target);
     }
 }

--- a/Library/Services/INfieldSurveysService.cs
+++ b/Library/Services/INfieldSurveysService.cs
@@ -13,12 +13,11 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Nfield.Models;
 using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Nfield.Models;
-using Nfield.Quota;
 
 namespace Nfield.Services
 {
@@ -105,12 +104,6 @@ namespace Nfield.Services
         #region Quota for a survey
 
         /// <summary>
-        /// Gets quota definition for survey.
-        /// </summary>
-        [Obsolete("NfieldSurveysService.QuotaQueryAsync is obsolete, please use NfieldSurveyQuotaFrameService.QuotaQueryAsync instead.")]
-        Task<QuotaLevel> QuotaQueryAsync(string surveyId);
-
-        /// <summary>
         /// Gets quota frame definition for survey.
         /// </summary>
         Task<SDK.Models.QuotaFrame> QuotaTargetsQueryAsync(string surveyId);
@@ -119,30 +112,6 @@ namespace Nfield.Services
         /// Gets quota frame definition for survey, using eTag version
         /// </summary>
         Task<SDK.Models.QuotaFrame> QuotaTargetsQueryAsync(string surveyId, string eTag);
-
-        /// <summary>
-        /// Get the quota definition for an online survey
-        /// </summary>
-        /// <param name="surveyId"></param>
-        /// <returns></returns>
-        [Obsolete("NfieldSurveysService.OnlineQuotaQueryAsync is obsolete, please use NfieldSurveyQuotaFrameService.QuotaQueryAsync instead.")]
-        Task<QuotaFrame> OnlineQuotaQueryAsync(string surveyId);
-
-        /// <summary>
-        /// Assigns the supplied <paramref name="quota"/> to the survey with the provided <paramref name="surveyId"/>.
-        /// When this method is called on a survey that has a quota frame already 
-        /// then the frame is completely replaced by the new one.
-        /// </summary>
-        [Obsolete("NfieldSurveysService.CreateOrUpdateQuotaAsync is obsolete, please use NfieldSurveyQuotaFrameService.CreateOrUpdateQuotaAsync instead.")]
-        Task<QuotaLevel> CreateOrUpdateQuotaAsync(string surveyId, QuotaLevel quota);
-
-        /// <summary>
-        /// Assigns the supplied <paramref name="quotaFrame"/> to the survey with the provided <paramref name="surveyId"/>.
-        /// When this method is called on a survey that has a quota frame already 
-        /// then the frame is completely replaced by the new one.
-        /// </summary>
-        [Obsolete("NfieldSurveysService.CreateOrUpdateQuotaAsync is obsolete, please use NfieldSurveyQuotaFrameService.CreateOrUpdateQuotaAsync instead.")]
-        Task<QuotaFrame> CreateOrUpdateOnlineQuotaAsync(string surveyId, QuotaFrame quotaFrame);
 
         #endregion
 

--- a/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
@@ -1,0 +1,87 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+namespace Nfield.SDK.Services.Implementation
+{
+    internal class NfieldSamplingPointsQuotaTargetsService : INfieldSamplingPointsQuotaTargetsService, INfieldConnectionClientObject
+    {
+
+        /// <summary>
+        /// See <see cref="INfieldSurveysService.UpdateAsync"/>
+        /// </summary>
+        public Task<SamplingPointQuotaTarget> GetAsync(string surveyId, string samplingPointId, string quotaLevelId)
+        {
+            return ConnectionClient.Client.GetAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId, quotaLevelId))
+             .ContinueWith(
+                 responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+             .ContinueWith(
+                 stringTask =>
+                 JsonConvert.DeserializeObject<SamplingPointQuotaTarget>(stringTask.Result))
+             .FlattenExceptions();
+        }
+
+        public Task<IQueryable<SamplingPointQuotaTarget>> QueryAsync(string surveyId, string samplingPointId)
+        {
+            return ConnectionClient.Client.GetAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId))
+             .ContinueWith(
+                 responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+             .ContinueWith(
+                 stringTask =>
+                 JsonConvert.DeserializeObject<List<SamplingPointQuotaTarget>>(stringTask.Result).AsQueryable())
+             .FlattenExceptions();
+        }
+
+        public Task<IQueryable<SamplingPointQuotaTarget>> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target)
+        {
+            return ConnectionClient.Client.PatchAsJsonAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId, quotaLevelId), new { Target = target })
+             .ContinueWith(
+                 responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+             .ContinueWith(
+                 stringTask =>
+                 JsonConvert.DeserializeObject<List<SamplingPointQuotaTarget>>(stringTask.Result).AsQueryable())
+             .FlattenExceptions();
+        }
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Constructs and returns the url for sampling points quota targets code 
+        /// based on supplied <paramref name="surveyId"/>  and <paramref name="samplingPointId"/>
+        /// </summary>
+        private Uri SamplingPointsQuotaTargetsApi(string surveyId, string samplingPointId, string quotaLevelId = "")
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/SamplingPoints/{samplingPointId}/QuotaTargets/{quotaLevelId}");
+        }
+    }
+}

--- a/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
@@ -29,7 +29,7 @@ namespace Nfield.SDK.Services.Implementation
     {
 
         /// <summary>
-        /// See <see cref="INfieldSurveysService.UpdateAsync"/>
+        /// See <see cref="INfieldSamplingPointsQuotaTargetsService.GetAsync"/>
         /// </summary>
         public Task<SamplingPointQuotaTarget> GetAsync(string surveyId, string samplingPointId, string quotaLevelId)
         {
@@ -42,6 +42,9 @@ namespace Nfield.SDK.Services.Implementation
              .FlattenExceptions();
         }
 
+        /// <summary>
+        /// See <see cref="INfieldSamplingPointsQuotaTargetsService.GetAsync"/>
+        /// </summary>
         public Task<IQueryable<SamplingPointQuotaTarget>> QueryAsync(string surveyId, string samplingPointId)
         {
             return ConnectionClient.Client.GetAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId))
@@ -53,6 +56,9 @@ namespace Nfield.SDK.Services.Implementation
              .FlattenExceptions();
         }
 
+        /// <summary>
+        /// See <see cref="INfieldSamplingPointsQuotaTargetsService.PatchAsync(string, string, string, int?)"/>
+        /// </summary>
         public Task<SamplingPointQuotaTarget> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target)
         {
             return ConnectionClient.Client.PatchAsJsonAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId, quotaLevelId), new { Target = target })

--- a/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
@@ -57,7 +57,7 @@ namespace Nfield.SDK.Services.Implementation
         }
 
         /// <summary>
-        /// See <see cref="INfieldSamplingPointsQuotaTargetsService.PatchAsync(string, string, string, int?)"/>
+        /// See <see cref="INfieldSamplingPointsQuotaTargetsService.PatchAsync"/>
         /// </summary>
         public Task<SamplingPointQuotaTarget> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target)
         {

--- a/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
+++ b/Library/Services/Implementation/NfieldSamplingPointsQuotaTargetsService.cs
@@ -53,14 +53,14 @@ namespace Nfield.SDK.Services.Implementation
              .FlattenExceptions();
         }
 
-        public Task<IQueryable<SamplingPointQuotaTarget>> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target)
+        public Task<SamplingPointQuotaTarget> PatchAsync(string surveyId, string samplingPointId, string quotaLevelId, int? target)
         {
             return ConnectionClient.Client.PatchAsJsonAsync(SamplingPointsQuotaTargetsApi(surveyId, samplingPointId, quotaLevelId), new { Target = target })
              .ContinueWith(
                  responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
              .ContinueWith(
                  stringTask =>
-                 JsonConvert.DeserializeObject<List<SamplingPointQuotaTarget>>(stringTask.Result).AsQueryable())
+                 JsonConvert.DeserializeObject<SamplingPointQuotaTarget>(stringTask.Result))
              .FlattenExceptions();
         }
 

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.72.{buildId}{suffix}
+2.73.{buildId}{suffix}


### PR DESCRIPTION
[AB#141447](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/141447)

- Remove the service related to the deleted controller
- Add a new service for the `NfieldSamplingPointsQuotaTargets `controller

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-yellow