### PR TITLE
Add missing RepositorySurvey endpoints

### DIFF
--- a/Library/Services/INfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/INfieldDeliveryRepositorySurveysService.cs
@@ -43,7 +43,7 @@ namespace Nfield.Services
         /// </summary>
         /// <param name="repositoryId">The repository id.</param>
         /// <param name="surveyId">The id of the survey to be reinitiated</param>
-        Task PutReinitiateAsync(long repositoryId, string surveyId);
+        Task ReinitiateAsync(long repositoryId, string surveyId);
 
         /// <summary>
         /// Deletes the selected survey from the repository.

--- a/Library/Services/INfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/INfieldDeliveryRepositorySurveysService.cs
@@ -30,5 +30,26 @@ namespace Nfield.Services
         /// <param name="repositoryId">The repository id.</param>
         /// <returns>The repository surveys.</returns>         
         Task<IQueryable<RepositorySurveyModel>> QueryAsync(long repositoryId);
+
+        /// <summary>
+        /// Adds the selected surveys to the repository.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="nfieldSurveyIds">The surveys to add</param>
+        Task PostAsync(long repositoryId, string[] nfieldSurveyIds);
+
+        /// <summary>
+        /// Reinitiates a paused Survey in the selected Repository.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="surveyId">The id of the survey to be reinitiated</param>
+        Task PutReinitiateAsync(long repositoryId, string surveyId);
+
+        /// <summary>
+        /// Deletes the selected survey from the repository.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="surveyId">The id of the survey to be removed</param>
+        Task DeleteAsync(long repositoryId, string surveyId);       
     }
 }

--- a/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
@@ -55,7 +55,7 @@ namespace Nfield.SDK.Services.Implementation
                          .FlattenExceptions();          
         }
 
-        public Task PutReinitiateAsync(long repositoryId, string surveyId)
+        public Task ReinitiateAsync(long repositoryId, string surveyId)
         {
             var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Surveys/{surveyId}/reinitiate");
             return ConnectionClient.Client.PutAsync(uri, null)

--- a/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
@@ -16,10 +16,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
+using Nfield.Models;
 using Nfield.SDK.Models.Delivery;
 using Nfield.Services;
 
@@ -45,6 +47,28 @@ namespace Nfield.SDK.Services.Implementation
                          .FlattenExceptions();
         }
 
+        public Task PostAsync(long repositoryId, string[] nfieldSurveyIds)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Surveys");
+
+            return ConnectionClient.Client.PostAsJsonAsync(uri, nfieldSurveyIds)
+                         .FlattenExceptions();          
+        }
+
+        public Task PutReinitiateAsync(long repositoryId, string surveyId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Surveys/{surveyId}/reinitiate");
+            return ConnectionClient.Client.PutAsync(uri, null)
+                        .FlattenExceptions();
+        }
+
+        public Task DeleteAsync(long repositoryId, string surveyId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Surveys/{surveyId}");
+
+            return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
+        }
+
 
         #endregion
 
@@ -55,7 +79,7 @@ namespace Nfield.SDK.Services.Implementation
         public void InitializeNfieldConnection(INfieldConnectionClient connection)
         {
             ConnectionClient = connection;
-        }
+        }        
 
         #endregion
 

--- a/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
@@ -97,7 +97,7 @@ namespace Nfield.Services
             var target = new NfieldDeliveryRepositorySurveysService();
             target.InitializeNfieldConnection(mockedNfieldConnection.Object);
 
-            await target.PutReinitiateAsync(repositoryId, surveyId);
+            await target.ReinitiateAsync(repositoryId, surveyId);
 
             mockedHttpClient.Verify();
         }

--- a/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
@@ -56,5 +56,73 @@ namespace Nfield.Services
             mockedHttpClient.Verify();
             Assert.Equal(repositorySurveyModels.First().Id, actual.First().Id);
         }
+
+        [Fact]
+        public async Task Test_PostAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var nfieldSurveyIds = new string[] { Guid.NewGuid().ToString() };
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Surveys");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(endpointUri, nfieldSurveyIds))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositorySurveysService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PostAsync(repositoryId, nfieldSurveyIds);
+
+            mockedHttpClient.Verify();
+        }
+
+        [Fact]
+        public async Task Test_ReinitiateAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var surveyId = Guid.NewGuid().ToString();
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Surveys/{surveyId}/reinitiate");
+
+            mockedHttpClient
+                .Setup(client => client.PutAsync(endpointUri, null))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositorySurveysService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PutReinitiateAsync(repositoryId, surveyId);
+
+            mockedHttpClient.Verify();
+        }
+
+        [Fact]
+        public async Task Test_DeleteAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var surveyId = Guid.NewGuid().ToString();
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Surveys/{surveyId}");
+
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositorySurveysService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.DeleteAsync(repositoryId, surveyId);
+
+            mockedHttpClient.Verify();
+        }
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.75.{buildId}{suffix}
+2.76.{buildId}{suffix}


### PR DESCRIPTION
Related story: [AB#141109](https://dev.azure.com/niposoftware/Nfield/_workitems/edit/141109)

**Description**
Add missing RepositorySurvey endpoints in `NfieldDeliveryRepositorySurveysService`

**Implementation**
- [x] Add missing endpoints

**Tests** 
- [x] Integration tests have been performed
