### PR TITLE
Added start simulation functionality

### DIFF
--- a/Library/Extensions/NfieldConnectionClientExtensions.cs
+++ b/Library/Extensions/NfieldConnectionClientExtensions.cs
@@ -39,7 +39,7 @@ namespace Nfield.Extensions
         /// <param name="activityId">The id of the activity to wait for.</param>
         /// <param name="fieldNameResult">The name of the result field</param>
         /// <returns>The <see cref="BackgroundActivityStatus" /> id.</returns>
-        internal static async Task<T> GetActivityResultAsync<T>(this INfieldConnectionClient connectionClient, string activityId, string fieldNameResult)
+        internal static async Task<T> GetActivityResultAsync<T>(this INfieldConnectionClient connectionClient, string activityId, string fieldNameResult = null)
         {
             while (true)
             {
@@ -56,8 +56,8 @@ namespace Nfield.Extensions
                     case 1: // started
                         await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
                         break;
-                    case 2: // succeeded
-                        return obj[fieldNameResult].Value<T>();
+                    case 2: // succeeded                       
+                        return fieldNameResult == null ? obj.ToObject<T>() : obj[fieldNameResult].Value<T>();                        
                     case 3: // failed
                     default:
                         throw new NfieldErrorException("Action did not complete successfully");

--- a/Library/Models/InterviewSimulation.cs
+++ b/Library/Models/InterviewSimulation.cs
@@ -18,7 +18,7 @@ namespace Nfield.Models
     /// <summary>
     /// Parameters to start interview simulation.
     /// To specify uploaded files this model uses the file name and the file content as a text string.
-    /// To upload data form a file path use <see cref="InterviewSimulationFiles"/>
+    /// To upload data directly from files use <see cref="InterviewSimulationFiles"/>
     /// </summary>
     public class InterviewSimulation
     {

--- a/Library/Models/InterviewSimulation.cs
+++ b/Library/Models/InterviewSimulation.cs
@@ -1,0 +1,60 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Parameters to start interview simulation.
+    /// To specify uploaded files this model uses the file name and the file content as a text string.
+    /// To upload data form a file path use <see cref="InterviewSimulationFiles"/>
+    /// </summary>
+    public class InterviewSimulation
+    {
+        /// <summary>
+        /// Number of interviews to be simulated
+        /// </summary>
+        public int InterviewsCount { get; set; }
+
+        /// <summary>
+        /// Enable reporting for the simulation
+        /// </summary>
+        public bool EnableReporting { get; set; }
+
+        /// <summary>
+        /// Use sample data from the original survey
+        /// </summary>
+        public bool UseOriginalSample { get; set; }
+
+        /// <summary>
+        /// Hints file name
+        /// </summary>
+        public string HintsFileName { get; set; }
+
+        /// <summary>
+        /// Hints data
+        /// </summary>
+        public string Hints { get; set; }
+
+        /// <summary>
+        /// Sample data file name
+        /// </summary>
+        public string SampleDataFileName { get; set;}
+
+        /// <summary>
+        /// Sample data
+        /// </summary>
+        public string SampleData { get; set; }
+    }
+}

--- a/Library/Models/InterviewSimulation.cs
+++ b/Library/Models/InterviewSimulation.cs
@@ -45,7 +45,7 @@ namespace Nfield.Models
         /// <summary>
         /// Hints data
         /// </summary>
-        public string Hints { get; set; }
+        public string HintsFile { get; set; }
 
         /// <summary>
         /// Sample data file name
@@ -55,6 +55,6 @@ namespace Nfield.Models
         /// <summary>
         /// Sample data
         /// </summary>
-        public string SampleData { get; set; }
+        public string SampleDataFile { get; set; }
     }
 }

--- a/Library/Models/InterviewSimulationFiles.cs
+++ b/Library/Models/InterviewSimulationFiles.cs
@@ -1,0 +1,49 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Parameters to start interview simulation.
+    /// This model allows to upload hints and sample data using the file path.
+    /// </summary>
+    public class InterviewSimulationFiles
+    {
+        /// <summary>
+        /// Number of interviews to be simulated
+        /// </summary>
+        public int InterviewsCount { get; set; }
+
+        /// <summary>
+        /// Enable reporting for the simulation
+        /// </summary>
+        public bool EnableReporting { get; set; }
+
+        /// <summary>
+        /// Use sample data from the original survey
+        /// </summary>
+        public bool UseOriginalSample { get; set; }
+
+        /// <summary>
+        /// Path to the hints file
+        /// </summary>
+        public string HintsFilePath { get; set; }
+
+        /// <summary>
+        /// Path to the sample data file
+        /// </summary>
+        public string SampleDataFilePath { get; set;}
+    }
+}

--- a/Library/Models/InterviewSimulationResult.cs
+++ b/Library/Models/InterviewSimulationResult.cs
@@ -1,0 +1,45 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Interview simulation result
+    /// </summary>
+    public class InterviewSimulationResult
+    {
+        /// <summary>
+        /// Survey id of the original survey
+        /// </summary>
+        public string OriginalSurveyId { get; set; }
+
+        /// <summary>
+        /// Number of requested simulated interviews
+        /// </summary>
+        public int RequestedInterviewsCount { get; set; }
+
+        /// <summary>
+        /// Survey id of the simulation survey
+        /// </summary>
+        public string SimulationSurveyId { get; set; }
+
+        /// <summary>
+        /// Error messages (if any)
+        /// </summary>
+        public IEnumerable<string> ErrorMessages { get; set; } = new List<string>();
+    }
+}

--- a/Library/Services/INfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/INfieldSurveyInterviewSimulationService.cs
@@ -13,6 +13,7 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Nfield.Models;
 using System;
 using System.Threading.Tasks;
 
@@ -29,5 +30,20 @@ namespace Nfield.Services
         /// <param name="surveyId">Id of the simulation survey</param>
         /// <returns>URI of the hints file</returns>
         Task<Uri> GetHintsAsync(string surveyId);
+
+        /// <summary>
+        /// Starts interview simulation.
+        /// </summary>
+        /// <param name="surveyId">The survey id</param>
+        /// <param name="simulationRequest">Parameters to start the simulations</param>
+        Task StartSimulationAsync(string surveyId, InterviewSimulation simulationRequest);
+
+        /// <summary>
+        /// Starts interview simulation.
+        /// This one allows to upload  hints and sample data directly from files.  
+        /// </summary>
+        /// <param name="surveyId">The survey id</param>
+        /// <param name="simulationRequest">Parameters to start the simulations</param>
+        Task StartSimulationAsync(string surveyId, InterviewSimulationFiles simulationRequest);
     }
 }

--- a/Library/Services/INfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/INfieldSurveyInterviewSimulationService.cs
@@ -36,7 +36,7 @@ namespace Nfield.Services
         /// </summary>
         /// <param name="surveyId">The survey id</param>
         /// <param name="simulationRequest">Parameters to start the simulations</param>
-        Task StartSimulationAsync(string surveyId, InterviewSimulation simulationRequest);
+        Task<InterviewSimulationResult> StartSimulationAsync(string surveyId, InterviewSimulation simulationRequest);
 
         /// <summary>
         /// Starts interview simulation.
@@ -44,6 +44,6 @@ namespace Nfield.Services
         /// </summary>
         /// <param name="surveyId">The survey id</param>
         /// <param name="simulationRequest">Parameters to start the simulations</param>
-        Task StartSimulationAsync(string surveyId, InterviewSimulationFiles simulationRequest);
+        Task<InterviewSimulationResult> StartSimulationAsync(string surveyId, InterviewSimulationFiles simulationRequest);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
@@ -76,6 +76,9 @@ namespace Nfield.Services.Implementation
         /// </summary>
         public async Task StartSimulationAsync(string surveyId, InterviewSimulationFiles simulationRequest)
         {
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+            Ensure.ArgumentNotNull(simulationRequest, nameof(simulationRequest));
+
             var interviewSimulation = new InterviewSimulation
             {
                 InterviewsCount = simulationRequest.InterviewsCount,

--- a/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
@@ -94,7 +94,7 @@ namespace Nfield.Services.Implementation
                     throw new FileNotFoundException(fileName);
 
                 interviewSimulation.HintsFileName = fileName;
-                interviewSimulation.Hints = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
+                interviewSimulation.HintsFile = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
             }
 
             if (!string.IsNullOrEmpty(simulationRequest.SampleDataFilePath))
@@ -105,7 +105,7 @@ namespace Nfield.Services.Implementation
                     throw new FileNotFoundException(fileName);
 
                 interviewSimulation.SampleDataFileName = fileName;
-                interviewSimulation.SampleData = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
+                interviewSimulation.SampleDataFile = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
             }
 
             await StartSimulationAsync(surveyId, interviewSimulation);
@@ -148,14 +148,14 @@ namespace Nfield.Services.Implementation
                 { new StringContent($"{simulationRequest.UseOriginalSample}"), nameof(simulationRequest.UseOriginalSample) }
             };
 
-            if (!string.IsNullOrEmpty(simulationRequest.HintsFileName) && !string.IsNullOrEmpty(simulationRequest.Hints))
+            if (!string.IsNullOrEmpty(simulationRequest.HintsFileName) && !string.IsNullOrEmpty(simulationRequest.HintsFile))
             {
-                content.Add(new StringContent(simulationRequest.Hints), nameof(simulationRequest.Hints), simulationRequest.HintsFileName);
+                content.Add(new StringContent(simulationRequest.HintsFile), nameof(simulationRequest.HintsFile), simulationRequest.HintsFileName);
             }
 
-            if (!string.IsNullOrEmpty(simulationRequest.SampleDataFileName) && !string.IsNullOrEmpty(simulationRequest.SampleData))
+            if (!string.IsNullOrEmpty(simulationRequest.SampleDataFileName) && !string.IsNullOrEmpty(simulationRequest.SampleDataFile))
             {
-                content.Add(new StringContent(simulationRequest.SampleData), nameof(simulationRequest.SampleData), simulationRequest.SampleDataFileName);
+                content.Add(new StringContent(simulationRequest.SampleDataFile), nameof(simulationRequest.SampleDataFile), simulationRequest.SampleDataFileName);
             }
 
             content.Headers.ContentType.MediaType = "multipart/form-data";

--- a/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
@@ -13,9 +13,15 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Newtonsoft.Json;
+using Nfield.Extensions;
 using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Models.NipoSoftware.Nfield.Manager.Api.Models;
+using Nfield.Utilities;
 using System;
-
+using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Nfield.Services.Implementation
@@ -25,6 +31,21 @@ namespace Nfield.Services.Implementation
     /// </summary>
     internal class NfieldSurveyInterviewSimulationService : INfieldSurveyInterviewSimulationService, INfieldConnectionClientObject
     {
+        readonly IFileSystem _fileSystem;
+
+        public NfieldSurveyInterviewSimulationService()
+        {
+            _fileSystem = new FileSystem();
+        }
+
+        public NfieldSurveyInterviewSimulationService(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// <see cref="INfieldSurveyInterviewSimulationService.GetHintsAsync(string)"/>
+        /// </summary>
         public async Task<Uri> GetHintsAsync(string surveyId)
         {
             using (var response = await Client.GetAsync(SurveySimulationHintsEndPoint(surveyId)).ConfigureAwait(false))
@@ -32,6 +53,59 @@ namespace Nfield.Services.Implementation
                 var uri = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new Uri(uri);
             }
+        }
+
+        /// <summary>
+        /// <see cref="INfieldSurveyInterviewSimulationService.StartSimulationAsync(string, InterviewSimulation)"/>
+        /// </summary>
+        public async Task StartSimulationAsync(string surveyId, InterviewSimulation simulationRequest)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+            Ensure.ArgumentNotNull(simulationRequest, nameof(simulationRequest));
+
+            var content = MultipartDataContent(simulationRequest);
+
+            var response = await Client.PostAsync(StartInterviewSimulationsEndPoint(surveyId), content).ConfigureAwait(false);
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var backgroundActivityStatus = JsonConvert.DeserializeObject<BackgroundActivityStatus>(result);
+            _ = await ConnectionClient.GetActivityResultAsync<string>(backgroundActivityStatus.ActivityId, "Status").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="INfieldSurveyInterviewSimulationService.StartSimulationAsync(string, InterviewSimulationFiles)"/>
+        /// </summary>
+        public async Task StartSimulationAsync(string surveyId, InterviewSimulationFiles simulationRequest)
+        {
+            var interviewSimulation = new InterviewSimulation
+            {
+                InterviewsCount = simulationRequest.InterviewsCount,
+                EnableReporting = simulationRequest.EnableReporting,
+                UseOriginalSample = simulationRequest.UseOriginalSample
+            };
+
+            if (!string.IsNullOrEmpty(simulationRequest.HintsFilePath))
+            {
+                var fileName = _fileSystem.Path.GetFileName(simulationRequest.HintsFilePath);
+
+                if (!_fileSystem.File.Exists(simulationRequest.HintsFilePath))
+                    throw new FileNotFoundException(fileName);
+
+                interviewSimulation.HintsFileName = fileName;
+                interviewSimulation.Hints = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
+            }
+
+            if (!string.IsNullOrEmpty(simulationRequest.SampleDataFilePath))
+            {
+                var fileName = _fileSystem.Path.GetFileName(simulationRequest.SampleDataFilePath);
+
+                if (!_fileSystem.File.Exists(simulationRequest.SampleDataFilePath))
+                    throw new FileNotFoundException(fileName);
+
+                interviewSimulation.SampleDataFileName = fileName;
+                interviewSimulation.SampleData = _fileSystem.File.ReadAllText(simulationRequest.HintsFilePath);
+            }
+
+            await StartSimulationAsync(surveyId, interviewSimulation);
         }
 
         #region Implementation of INfieldConnectionClientObject
@@ -55,6 +129,35 @@ namespace Nfield.Services.Implementation
         private Uri SurveySimulationHintsEndPoint(string surveyId)
         {
             return new Uri(ConnectionClient.NfieldServerUri, $"surveys/{surveyId}/InterviewSimulations/DownloadHints");
+        }
+
+        private Uri StartInterviewSimulationsEndPoint(string surveyId)
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, $"surveys/{surveyId}/InterviewSimulations/StartInterviewSimulations");
+        }
+
+        private static MultipartFormDataContent MultipartDataContent(InterviewSimulation simulationRequest)
+        {
+            var content = new MultipartFormDataContent
+            {
+                { new StringContent($"{simulationRequest.InterviewsCount}"), nameof(simulationRequest.InterviewsCount) },
+                { new StringContent($"{simulationRequest.EnableReporting}"), nameof(simulationRequest.EnableReporting) },
+                { new StringContent($"{simulationRequest.UseOriginalSample}"), nameof(simulationRequest.UseOriginalSample) }
+            };
+
+            if (!string.IsNullOrEmpty(simulationRequest.HintsFileName) && !string.IsNullOrEmpty(simulationRequest.Hints))
+            {
+                content.Add(new StringContent(simulationRequest.Hints), nameof(simulationRequest.Hints), simulationRequest.HintsFileName);
+            }
+
+            if (!string.IsNullOrEmpty(simulationRequest.SampleDataFileName) && !string.IsNullOrEmpty(simulationRequest.SampleData))
+            {
+                content.Add(new StringContent(simulationRequest.SampleData), nameof(simulationRequest.SampleData), simulationRequest.SampleDataFileName);
+            }
+
+            content.Headers.ContentType.MediaType = "multipart/form-data";
+
+            return content;
         }
 
         #endregion


### PR DESCRIPTION
Functions to start interview simulation using different models. One can read data directly form the file path, the other one requires the file name and the file content as a string.
Uinit tests will follow. 

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-blue