### PR TITLE
return content

### DIFF
--- a/Library/Services/INfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/INfieldSurveyInterviewSimulationService.cs
@@ -28,8 +28,8 @@ namespace Nfield.Services
         /// Get the URI of the simulation hints file of a survey simulation
         /// </summary>
         /// <param name="surveyId">Id of the simulation survey</param>
-        /// <returns>URI of the hints file</returns>
-        Task<Uri> GetHintsAsync(string surveyId);
+        /// <returns>Content of the hints file</returns>
+        Task<string> GetHintsAsync(string surveyId);
 
         /// <summary>
         /// Starts interview simulation.

--- a/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewSimulationService.cs
@@ -46,12 +46,12 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// <see cref="INfieldSurveyInterviewSimulationService.GetHintsAsync(string)"/>
         /// </summary>
-        public async Task<Uri> GetHintsAsync(string surveyId)
+        public async Task<string> GetHintsAsync(string surveyId)
         {
             using (var response = await Client.GetAsync(SurveySimulationHintsEndPoint(surveyId)).ConfigureAwait(false))
             {
-                var uri = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return new Uri(uri);
+                var hints = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return hints;
             }
         }
 


### PR DESCRIPTION
Return hint content instead of the URL (as we do for scripts)

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-purple