### PR TITLE
Support two new simulation endpoints

### DIFF
--- a/Library/Models/SurveyInterviewSimulation.cs
+++ b/Library/Models/SurveyInterviewSimulation.cs
@@ -1,0 +1,28 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+
+namespace Nfield.SDK.Models
+{
+    public class SurveyInterviewSimulation : Survey
+    {
+        public SurveyInterviewSimulation(SurveyType surveyType) : base(surveyType)
+        {
+        }
+
+        public string OriginalSurveyId { get; set; }
+    }
+}

--- a/Library/Services/INfieldSurveyInterviewSimulationService.cs
+++ b/Library/Services/INfieldSurveyInterviewSimulationService.cs
@@ -14,7 +14,8 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using Nfield.Models;
-using System;
+using Nfield.SDK.Models;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Nfield.Services
@@ -30,6 +31,19 @@ namespace Nfield.Services
         /// <param name="surveyId">Id of the simulation survey</param>
         /// <returns>Content of the hints file</returns>
         Task<string> GetHintsAsync(string surveyId);
+
+        /// <summary>
+        /// Retrieve all simulations.
+        /// </summary>
+        /// <returns></returns>
+        Task<IQueryable<SurveyInterviewSimulation>> GetInterviewSimulationsAsync();
+
+        /// <summary>
+        /// Retrieve the simulation of a survey.
+        /// </summary>
+        /// <param name="surveyId"></param>
+        /// <returns></returns>
+        Task<SurveyInterviewSimulation> GetSurveyInterviewSimulationAsync(string surveyId);
 
         /// <summary>
         /// Starts interview simulation.

--- a/Tests/Services/NfieldSurveyInterviewSimulationTests.cs
+++ b/Tests/Services/NfieldSurveyInterviewSimulationTests.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using Nfield.Infrastructure;
 using Nfield.Models;
 using Nfield.Models.NipoSoftware.Nfield.Manager.Api.Models;
+using Nfield.SDK.Models;
 using Nfield.Services.Implementation;
 using System;
 using System.Collections.Generic;
@@ -71,6 +72,68 @@ namespace Nfield.Services
 
             var actual = await _target.GetHintsAsync(_surveyId);
             Assert.Equal(Hints, actual);
+        }
+
+        [Fact]
+        public void TestGetInterviewSimulationsAsync_ServerReturnsQuery_ReturnsListWithSimulations()
+        {
+            var interviewSimulationsEndPoint = new Uri(ServiceAddress, "surveys/InterviewSimulations");
+
+            var expectedSimulationSurveys = new[]
+            {
+                new SurveyInterviewSimulation(SurveyType.Basic) { SurveyId = Guid.NewGuid().ToString() },
+                new SurveyInterviewSimulation(SurveyType.Advanced) { SurveyId = Guid.NewGuid().ToString() }
+            };
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.GetAsync(interviewSimulationsEndPoint))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedSimulationSurveys))));
+
+            var target = new NfieldSurveyInterviewSimulationService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actualSimulationSurveys = target.GetInterviewSimulationsAsync().Result;
+
+            Assert.Equal(expectedSimulationSurveys[0].SurveyId, actualSimulationSurveys.ToArray()[0].SurveyId);
+            Assert.Equal(expectedSimulationSurveys[1].SurveyId, actualSimulationSurveys.ToArray()[1].SurveyId);
+            Assert.Equal(2, actualSimulationSurveys.Count());
+        }
+
+        [Fact]
+        public void TestGetSurveyInterviewSimulationAsync_ServerReturnsQuery_ReturnsListWithSimulations()
+        {
+            var surveyId = Guid.NewGuid().ToString();
+            var expectedSimulationSurvey = new SurveyInterviewSimulation(SurveyType.Basic) { SurveyId = surveyId };
+
+            var surveyInterviewSimulationEndPoint = new Uri(ServiceAddress, $"surveys/{surveyId}/InterviewSimulation");
+
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.GetAsync(surveyInterviewSimulationEndPoint))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedSimulationSurvey))));
+
+            var target = new NfieldSurveyInterviewSimulationService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actualSimulationSurvey = target.GetSurveyInterviewSimulationAsync(surveyId).Result;
+
+            Assert.Equal(expectedSimulationSurvey.SurveyId, actualSimulationSurvey.SurveyId);
+        }
+
+        [Fact]
+        public void TestGetSurveyInterviewSimulationAsync_SurveyIdIsNull_Throws()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await _target.GetSurveyInterviewSimulationAsync(null));
+        }
+
+        [Fact]
+        public void TestGetSurveyInterviewSimulationAsync_SurveyIdIsEmptyString_Throws()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await _target.GetSurveyInterviewSimulationAsync(string.Empty));
         }
 
         #region StartSimulation


### PR DESCRIPTION
---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-purple