### PR TITLE
Add sync repository endpoint

### DIFF
--- a/Library/Services/INfieldDeliveryRepositoriesService.cs
+++ b/Library/Services/INfieldDeliveryRepositoriesService.cs
@@ -87,5 +87,11 @@ namespace Nfield.Services
         ///<returns> As this is a long running operation, it returns an <c>Accepted</c> response. The appropriate exception will be thrown in case of failure.</returns>
         Task DeleteAsync(long repositoryId);
 
+        /// <summary>
+        /// Triggers a repository sync.
+        /// </summary>
+        /// <param name="repositoryId">The repository Id.</param>
+        /// <returns><c>AcceptedResult</c>, if succeeded. The appropriate exception in case of failure. BadRequest in case of error.</returns>
+        Task PostSyncRepositoryAsync(long repositoryId);
     }
 }

--- a/Library/Services/Implementation/NfieldDeliveryRepositoriesService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositoriesService.cs
@@ -135,6 +135,13 @@ namespace Nfield.SDK.Services.Implementation
             return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
         }
 
+        public Task PostSyncRepositoryAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Sync");
+
+            return ConnectionClient.Client.PostAsync(uri,null).FlattenExceptions();
+        }
+
         #endregion
 
         #region Implementation of INfieldConnectionClientObject

--- a/Postman/Nfield Public API AAD.postman_collection.json
+++ b/Postman/Nfield Public API AAD.postman_collection.json
@@ -928,6 +928,90 @@
 					"response": []
 				},
 				{
+					"name": "Post Sync Repository",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Basic {{AuthenticationToken}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{origin-public-api}}/v1/Delivery/Repositories/{{RepositoryId}}/Sync",
+							"host": [
+								"{{origin-public-api}}"
+							],
+							"path": [
+								"v1",
+								"Delivery",
+								"Repositories",
+								"{{RepositoryId}}",
+								"Sync"
+							]
+						}
+					},
+					"response": []
+				},
+				{		
+					"name": "Post Sync Repository",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Status code name has string\", function () {\r",
+									"    pm.response.to.have.status(\"OK\");\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{BearerToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-Nfield-Domain",
+								"value": "{{DomainTestName}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{origin-public-api}}/v1/Delivery/Repositories/{{RepositoryId}}/Sync",
+							"host": [
+								"{{origin-public-api}}"
+							],
+							"path": [
+								"v1",
+								"Delivery",
+								"Repositories",
+								"{{RepositoryId}}",
+								"Sync"
+							]
+						},
+						"description": "Triggers a manual repository sync."
+					},
+					"response": []
+				},
+				{
 					"name": "Delete Repository",
 					"event": [
 						{

--- a/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
@@ -245,5 +245,26 @@ namespace Nfield.Services
 
             mockedHttpClient.Verify();
         }
+
+        [Fact]
+        public async Task Test_PostSyncRepositoryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Sync");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsync(endpointUri, null))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PostSyncRepositoryAsync(repositoryId);
+
+            mockedHttpClient.Verify();
+        }
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.82.{buildId}{suffix}
+2.83.{buildId}{suffix}


### PR DESCRIPTION
Related story: [AB#145686](https://dev.azure.com/niposoftware/Nfield/_workitems/edit/145686)

**Description**

This PR adds support for triggering manually a repository sync

**Implementation**

- [x] Update `NfieldDeliveryRepositoriesService` with the public api endpoint for the manual repository sync
- [x] Update test
- [x] Update postman collection
- [x] Update version

**Tests** 

- [x] Tested manually in green dev environment