### PR TITLE
.Net8: Migrate MediaFiles, MediaFilesCount + QuotaVersions controllers

### DIFF
--- a/Library/Services/Implementation/NfieldMediaFilesService.cs
+++ b/Library/Services/Implementation/NfieldMediaFilesService.cs
@@ -130,7 +130,7 @@ namespace Nfield.Services.Implementation
             path.AppendFormat("Surveys/{0}/MediaFiles/", surveyId);
             if (!string.IsNullOrEmpty(fileName))
             {
-                path.AppendFormat("?fileName={0}", HttpUtility.UrlEncode(fileName));
+                path.AppendFormat("{0}", HttpUtility.UrlEncode(fileName));
             }
             return new Uri(ConnectionClient.NfieldServerUri, path.ToString());
         }


### PR DESCRIPTION
We don't support query params only path params

---

> team(s) or team member(s) automatically mentioned by [CodeGurusBot](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/Agreements/codegurus.md). If you want to review this PR, please self-request a review.

@NIPOSoftwareBV/team-yellow