### PR TITLE
.Net8: Migrate MediaFiles, MediaFilesCount + QuotaVersions controllers

### DIFF
--- a/Library/Services/Implementation/NfieldMediaFilesService.cs
+++ b/Library/Services/Implementation/NfieldMediaFilesService.cs
@@ -130,7 +130,7 @@ namespace Nfield.Services.Implementation
             path.AppendFormat("Surveys/{0}/MediaFiles/", surveyId);
             if (!string.IsNullOrEmpty(fileName))
             {
-                path.AppendFormat("?fileName={0}", HttpUtility.UrlEncode(fileName));
+                path.AppendFormat("{0}", HttpUtility.UrlEncode(fileName));
             }
             return new Uri(ConnectionClient.NfieldServerUri, path.ToString());
         }

--- a/Tests/Services/NfieldMediaFilesServiceTests.cs
+++ b/Tests/Services/NfieldMediaFilesServiceTests.cs
@@ -13,6 +13,10 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Services.Implementation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,10 +24,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Moq;
-using Newtonsoft.Json;
-using Nfield.Infrastructure;
-using Nfield.Services.Implementation;
 using Xunit;
 
 namespace Nfield.Services
@@ -92,7 +92,7 @@ namespace Nfield.Services
             var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             mockedHttpClient
-                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/?fileName=" + fileName)))
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/" + fileName)))
                 .Returns(CreateTask(HttpStatusCode.OK, new ByteArrayContent(expected)));
 
             var target = new NfieldMediaFilesService();
@@ -115,7 +115,7 @@ namespace Nfield.Services
             var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             mockedHttpClient
-                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/?fileName=MyFileName%26")))
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/MyFileName%26")))
                 .Returns(CreateTask(HttpStatusCode.OK, new ByteArrayContent(expected)));
 
             var target = new NfieldMediaFilesService();
@@ -165,7 +165,7 @@ namespace Nfield.Services
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             var response = new StringContent(JsonConvert.SerializeObject(new { ActivityId = "activityId" }));
             mockedHttpClient
-                .Setup(client => client.PostAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/?fileName=" + fileName),
+                .Setup(client => client.PostAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/" + fileName),
                         It.IsAny<HttpContent>()))
                 .Returns(CreateTask(HttpStatusCode.OK, response));
 

--- a/Tests/Services/NfieldMediaFilesServiceTests.cs
+++ b/Tests/Services/NfieldMediaFilesServiceTests.cs
@@ -92,7 +92,7 @@ namespace Nfield.Services
             var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             mockedHttpClient
-                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/" + fileName)))
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, $"Surveys/{surveyId}/MediaFiles/{fileName}")))
                 .Returns(CreateTask(HttpStatusCode.OK, new ByteArrayContent(expected)));
 
             var target = new NfieldMediaFilesService();
@@ -115,7 +115,7 @@ namespace Nfield.Services
             var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             mockedHttpClient
-                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/MyFileName%26")))
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, $"Surveys/{surveyId}/MediaFiles/MyFileName%26")))
                 .Returns(CreateTask(HttpStatusCode.OK, new ByteArrayContent(expected)));
 
             var target = new NfieldMediaFilesService();
@@ -165,7 +165,7 @@ namespace Nfield.Services
             var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
             var response = new StringContent(JsonConvert.SerializeObject(new { ActivityId = "activityId" }));
             mockedHttpClient
-                .Setup(client => client.PostAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/MediaFiles/" + fileName),
+                .Setup(client => client.PostAsync(new Uri(ServiceAddress, $"Surveys/{surveyId}/MediaFiles/{fileName}"),
                         It.IsAny<HttpContent>()))
                 .Returns(CreateTask(HttpStatusCode.OK, response));
 

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.85.{buildId}{suffix}
+2.86.{buildId}{suffix}


### PR DESCRIPTION
[AB#148873](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/148873)
We don't support query params, we only allow 