### PR TITLE
DistributeAsync now returns HttpResponseMessage

### DIFF
--- a/Library/Services/INfieldSurveyInterviewerWorkpackageDistributionService.cs
+++ b/Library/Services/INfieldSurveyInterviewerWorkpackageDistributionService.cs
@@ -14,6 +14,7 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nfield.Models;
 
@@ -33,6 +34,6 @@ namespace Nfield.Services
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
-        Task DistributeAsync(string surveyId, SurveyInterviewerDistributeModel model);
+        Task<HttpResponseMessage> DistributeAsync(string surveyId, SurveyInterviewerDistributeModel model);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyInterviewerWorkpackageDistributionService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewerWorkpackageDistributionService.cs
@@ -14,6 +14,7 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
@@ -25,7 +26,7 @@ namespace Nfield.Services.Implementation
     {
         #region Implementation of INfieldSurveyInterviewerWorkpackageDistributionService
 
-        public Task DistributeAsync(string surveyId, SurveyInterviewerDistributeModel model)
+        public Task<HttpResponseMessage> DistributeAsync(string surveyId, SurveyInterviewerDistributeModel model)
         {
             if (string.IsNullOrEmpty(surveyId))
             {


### PR DESCRIPTION
New Public API does't throw exceptions unless was 500,
we need the HttpResponseMessage to test the public API properly