### PR TITLE
Fix url encoding

### DIFF
--- a/Library/Services/Implementation/NfieldMediaFilesService.cs
+++ b/Library/Services/Implementation/NfieldMediaFilesService.cs
@@ -24,7 +24,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace Nfield.Services.Implementation
 {
@@ -130,7 +129,7 @@ namespace Nfield.Services.Implementation
             path.AppendFormat("Surveys/{0}/MediaFiles/", surveyId);
             if (!string.IsNullOrEmpty(fileName))
             {
-                path.AppendFormat("{0}", HttpUtility.UrlEncode(fileName));
+                path.AppendFormat("{0}", Uri.EscapeDataString(fileName));
             }
             return new Uri(ConnectionClient.NfieldServerUri, path.ToString());
         }


### PR DESCRIPTION
Public API supports both query params and path params but the new Public API only supports path params. We tried to make the affected endpoints compatible with both, but in .NET it seems not possible.

After checking that 0 requests were using the query params in all the production environments, we decided that it was safe to change the SDK to send the params as path params. Ironically, we are testing the endpoint by sending a query param that is not used and the help page only refers to path params `[GET v1/Surveys/{surveyId}/MediaFiles/{fileName}]`

Everything was tested manually and was working fine, however, depending on the type of params you send in the request, the encoding changes. So, file names with whitespaces are different.
- Query param: hello+world
- Path param: hello%20world

Luckily the test is sending a file with namespaces in the name and this is why it was failing. This change fixes the problem
