### PR TITLE
Media download filter

### DIFF
--- a/Library/Models/SurveyDataRequest.cs
+++ b/Library/Models/SurveyDataRequest.cs
@@ -91,25 +91,25 @@ namespace Nfield.Models
         public bool IncludeParaData { get; set; }
 
         /// <summary>
-        /// Include in the download the All captured Media Files during the interviews (AudioQuestion, VideoQuestion, PhotoQuestion, AudioSilentRecording)
+        /// Include in the download all captured Media files during the interviews (AudioQuestion, VideoQuestion, PhotoQuestion, AudioSilentRecording)
         /// </summary>
         public bool IncludeCapturedMediaFiles { get; set; }
         /// <summary>
-        /// Include Audio Silent Recording captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
+        /// Include in the download Audio Silent Recording captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
         /// </summary>
-        public bool IncludeCapturedAudioSilentRecordingFiles { get; set; } = false;
+        public bool IncludeCapturedAudioSilentRecordingFiles { get; set; }
         /// <summary>
-        /// Include Audio captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
+        /// Include in the download Audio captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
         /// </summary>
-        public bool IncludeCapturedAudioQuestionFiles { get; set; } = false;
+        public bool IncludeCapturedAudioQuestionFiles { get; set; }
         /// <summary>
-        /// Include Video captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
+        /// Include in the download Video captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
         /// </summary>
-        public bool IncludeCapturedVideoQuestionFiles { get; set; } = false;
+        public bool IncludeCapturedVideoQuestionFiles { get; set; }
         /// <summary>
-        /// Include Photo captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
+        ///Include in the download Photo captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
         /// </summary>
-        public bool IncludeCapturedPhotoQuestionFiles { get; set; } = false;
+        public bool IncludeCapturedPhotoQuestionFiles { get; set; }
 
         /// <summary>
         /// Include in the download the variables file of the interviews

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.1.{buildId}{suffix}
+3.2.{buildId}{suffix}


### PR DESCRIPTION
[AB#151176](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/151176)

The filters introduces the possibility to download only a subset of created media files

- **IncludeCapturedMediaFiles**  This is the current one that already exists to download all media files
Include in the download the All captured Media Files during the interviews (AudioQuestion, VideoQuestion, PhotoQuestion, AudioSilentRecording)


 - New  **IncludeCapturedAudioSilentRecordingFiles**
    Include Audio Silent Recording captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
 
 - New  **IncludeCapturedAudioQuestionFiles**
    Include Audio captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
 
 - New  **IncludeCapturedVideoQuestionFiles**
    Include Video captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
      
 - New  **IncludeCapturedPhotoQuestionFiles**
   Include Photo captured Files during the interviews. This parameter will be ignored if IncludeCapturedMediaFiles is true
   
Related PRs:
https://github.com/NIPOSoftwareBV/project-glu-api/pull/6721
https://github.com/NIPOSoftwareBV/nfield-public-api/pull/529
https://github.com/NIPOSoftwareBV/nfield-source/pull/9867
