### PR TITLE
Add NRG option for surveys created out of a online blueprint.

### DIFF
--- a/Library/Services/INfieldSurveysService.cs
+++ b/Library/Services/INfieldSurveysService.cs
@@ -41,7 +41,7 @@ namespace Nfield.Services
         /// <summary>
         /// Adds a new survey based on a blueprint survey.
         /// </summary>
-        Task<Survey> AddFromBlueprintAsync(string blueprintSurveyId, string surveyName);
+        Task<Survey> AddFromBlueprintAsync(string blueprintSurveyId, string surveyName, bool enableRespondentsGateway = false);
 
         /// <summary>
         /// Updates an existing blueprint survey based on a survey

--- a/Library/Services/Implementation/NfieldSurveysService.cs
+++ b/Library/Services/Implementation/NfieldSurveysService.cs
@@ -70,7 +70,7 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldSurveysService.AddFromBlueprintAsync"/>
         /// </summary>
-        public Task<Survey> AddFromBlueprintAsync(string blueprintSurveyId, string surveyName)
+        public Task<Survey> AddFromBlueprintAsync(string blueprintSurveyId, string surveyName, bool enableRespondentsGateway = false)
         {
             if (blueprintSurveyId == null)
             {
@@ -82,10 +82,11 @@ namespace Nfield.Services.Implementation
             }
 
             return Client.PostAsJsonAsync(new Uri(SurveysApi, "CreateSurveyFromBlueprint"), new
-                            {
-                                BlueprintSurveyId = blueprintSurveyId,
-                                SurveyName = surveyName
-                            })
+            {
+                BlueprintSurveyId = blueprintSurveyId,
+                SurveyName = surveyName,
+                EnableRespondentsGateway = enableRespondentsGateway
+            })
                          .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
                          .ContinueWith(task => JsonConvert.DeserializeObject<Survey>(task.Result))
                          .FlattenExceptions();
@@ -103,10 +104,10 @@ namespace Nfield.Services.Implementation
             }
 
             return Client.PutAsJsonAsync(new Uri(SurveyBlueprintsApi, blueprintSurveyId + "/Update"), new
-                            {
-                                SurveyId = surveyId,
-                                IncludedConfiguration = (int)includedConfiguration
-                            })
+            {
+                SurveyId = surveyId,
+                IncludedConfiguration = (int)includedConfiguration
+            })
                          .FlattenExceptions();
         }
 

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.7.{buildId}{suffix}
+3.8.{buildId}{suffix}


### PR DESCRIPTION
Related story: [AB#161792](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/161792)

**Description**

Add NRG option for surveys created out of a online blueprint.

**Implementation**

- [x] Modify INfieldSurveysService, NfieldSurveysService and tests to include `EnableRespondentsGateway`.

**Tests**

- [x] Manually executed all unit tests.