### PR TITLE
Add unit tests to new service ( landing page )

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -108,7 +108,8 @@ namespace Nfield.Infrastructure
             { typeof(INfieldParentSurveyWavesService), typeof(NfieldParentSurveyWavesService) },
             { typeof(INfieldSurveyManualTestsService), typeof(NfieldSurveyManualTestsService) },
             { typeof(INfieldSurveyInterviewerAssignmentService), typeof(NfieldSurveyInterviewerAssignmentService) },
-            { typeof(INfieldSurveyInterviewerQuotaLevelTargetsService), typeof(NfieldSurveyInterviewerQuotaLevelTargetsService) }
+            { typeof(INfieldSurveyInterviewerQuotaLevelTargetsService), typeof(NfieldSurveyInterviewerQuotaLevelTargetsService) },
+            { typeof(INfieldSurveyLandingPageService), typeof(NfieldSurveyLandingPageService) },
         };
 
 

--- a/Library/Services/INfieldSurveyLandingPageService.cs
+++ b/Library/Services/INfieldSurveyLandingPageService.cs
@@ -15,6 +15,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Nfield.Models;
 
 namespace Nfield.Services
 {
@@ -30,7 +31,7 @@ namespace Nfield.Services
         /// <param name="filePath">The path to the zip file.</param>
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="T:System.AggregateException"></exception>
-        Task<string> UploadLandingPageAsync(string surveyId, string filePath);
+        Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string filePath);
 
         /// <summary>
         /// Uploads a landing page zip file for a specific survey.
@@ -40,6 +41,6 @@ namespace Nfield.Services
         /// <param name="content">The content of the zip file as a stream.</param>
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="T:System.AggregateException"></exception>
-        Task<string> UploadLandingPageAsync(string surveyId, string fileName, Stream content);
+        Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string fileName, Stream content);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
-using Nfield.Models.NipoSoftware.Nfield.Manager.Api.Models;
 using Nfield.Utilities;
 using System;
 using System.IO;
@@ -43,7 +42,7 @@ namespace Nfield.Services.Implementation
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="FileNotFoundException">In case that the file does not exist</exception>
         /// <exception cref="T:System.AggregateException"></exception>
-        public async Task<string> UploadLandingPageAsync(string surveyId, string filePath)
+        public async Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string filePath)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
             Ensure.ArgumentNotNullOrEmptyString(filePath, nameof(filePath));
@@ -70,7 +69,7 @@ namespace Nfield.Services.Implementation
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="T:System.AggregateException"></exception>
-        public async Task<string> UploadLandingPageAsync(string surveyId, string fileName, Stream content)
+        public async Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
             Ensure.ArgumentNotNullOrEmptyString(fileName, nameof(fileName));
@@ -104,7 +103,7 @@ namespace Nfield.Services.Implementation
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/landingPage/");
         }
 
-        private async Task<string> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
+        private async Task<SurveyLandingPageUploadStatusResponseModel> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
             using (var formData = new MultipartFormDataContent())
             {
@@ -119,7 +118,7 @@ namespace Nfield.Services.Implementation
 
                 await ConnectionClient.GetActivityResultAsync<string>(uploadStatus.ActivityId, "Status").ConfigureAwait(false);
 
-                return uploadStatus.ActivityId;
+                return uploadStatus;
             }
         }
 

--- a/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
+++ b/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
@@ -1,0 +1,107 @@
+//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    public class NfieldSurveyLandingPageServiceTests : NfieldServiceTestsBase
+    {
+        #region UploadLandingPageAsync from file path
+
+        [Fact]
+        public void UploadLandingPageAsync_FileDoesNotExist_ThrowsFileNotFoundException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            var ex = Assert.ThrowsAsync<FileNotFoundException>(() =>
+                target.UploadLandingPageAsync("surveyId", "nonexistent.zip"));
+
+            Assert.Contains("does not exist", ex.Result.Message);
+        }
+
+        [Fact]
+        public void UploadLandingPageAsync_FilePathIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                target.UploadLandingPageAsync("surveyId", null));
+        }
+
+        #endregion
+
+        #region UploadLandingPageAsync with stream
+
+        [Fact]
+        public void UploadLandingPageAsync_StreamIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                target.UploadLandingPageAsync("surveyId", "landingPage.zip", null));
+        }
+
+        [Fact]
+        public async Task UploadLandingPageAsync_DoesNotThrow()
+        {
+            const string surveyId = "SurveyId";
+            const string fileName = "MyLandingPage.zip";
+            byte[] content = new byte[] { 1, 2, 3, 4, 5 };
+
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            var response = new StringContent(JsonConvert.SerializeObject(new { ActivityId = "activityId" }));
+
+            mockedHttpClient
+                .Setup(client => client.PostAsync(new Uri(ServiceAddress, $"Surveys/{surveyId}/landingPage/"),
+                        It.IsAny<HttpContent>()))
+                .Returns(CreateTask(HttpStatusCode.OK, response));
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(It.IsAny<Uri>()))
+                .Returns(Task.Factory.StartNew(
+                    () =>
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(new
+                        {
+                            ActivityId = "activityId",
+                            Status = 2 // Succeeded
+                        }))
+                    }))
+                .Verifiable();
+
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var stream = new MemoryStream(content);
+            await target.UploadLandingPageAsync(surveyId, fileName, stream);
+        }
+
+        #endregion
+    }
+}

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.91.{buildId}{suffix}
+3.10.{buildId}{suffix}


### PR DESCRIPTION
**Unit Tests Added**
New unit tests were created for the NfieldSurveyLandingPageService to cover the UploadLandingPageAsync method, ensuring robust handling of different scenarios:

**1. File Does Not Exist:**
Added a test to check that a FileNotFoundException is thrown when the specified file path does not exist.

**2. Null File Path:**
A test was added to verify that an ArgumentNullException is thrown when the file path is null.

**3. Null Stream:**
A test was added to ensure that an ArgumentNullException is thrown when the stream passed to UploadLandingPageAsync is null.

**4. Successful Upload:**
A test was implemented to confirm that the UploadLandingPageAsync method works correctly when provided with a valid file stream. It ensures that the service interacts with the mocked HTTP client as expected.