### PR TITLE
Add ExportLandingPage and unit tests

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -108,7 +108,8 @@ namespace Nfield.Infrastructure
             { typeof(INfieldParentSurveyWavesService), typeof(NfieldParentSurveyWavesService) },
             { typeof(INfieldSurveyManualTestsService), typeof(NfieldSurveyManualTestsService) },
             { typeof(INfieldSurveyInterviewerAssignmentService), typeof(NfieldSurveyInterviewerAssignmentService) },
-            { typeof(INfieldSurveyInterviewerQuotaLevelTargetsService), typeof(NfieldSurveyInterviewerQuotaLevelTargetsService) }
+            { typeof(INfieldSurveyInterviewerQuotaLevelTargetsService), typeof(NfieldSurveyInterviewerQuotaLevelTargetsService) },
+            { typeof(INfieldSurveyLandingPageService), typeof(NfieldSurveyLandingPageService) },
         };
 
 

--- a/Library/Models/CopyableSurveyConfiguration.cs
+++ b/Library/Models/CopyableSurveyConfiguration.cs
@@ -29,5 +29,8 @@ namespace Nfield.Models
         QuestionnaireScript = 2,
         TranslationLanguages = 4, // this is called "buttons and messages" in the UI
         MediaFiles = 8,
+        ResponseCodes = 16,
+        InterviewButtons = 32, // this is called "interview interactions" in the UI
+        LandingPage = 64,
     }
 }

--- a/Library/Models/SurveyLandingPageExportStatusResponseModel.cs
+++ b/Library/Models/SurveyLandingPageExportStatusResponseModel.cs
@@ -1,0 +1,35 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Represents the response model returned after exporting a landing page for a survey.
+    /// </summary>
+    public class SurveyLandingPageExportStatusResponseModel
+    {
+        /// <summary>
+        /// The status of the export operation (e.g., "Succeeded", "Failed").
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        /// The URL where the exported landing page zip file can be downloaded.
+        /// </summary>
+        public Uri DownloadUrl { get; set; }
+    }
+}

--- a/Library/Services/INfieldSurveyLandingPageService.cs
+++ b/Library/Services/INfieldSurveyLandingPageService.cs
@@ -15,6 +15,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Nfield.Models;
 
 namespace Nfield.Services
 {
@@ -30,7 +31,7 @@ namespace Nfield.Services
         /// <param name="filePath">The path to the zip file.</param>
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="T:System.AggregateException"></exception>
-        Task<string> UploadLandingPageAsync(string surveyId, string filePath);
+        Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string filePath);
 
         /// <summary>
         /// Uploads a landing page zip file for a specific survey.
@@ -40,6 +41,6 @@ namespace Nfield.Services
         /// <param name="content">The content of the zip file as a stream.</param>
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="T:System.AggregateException"></exception>
-        Task<string> UploadLandingPageAsync(string surveyId, string fileName, Stream content);
+        Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string fileName, Stream content);
     }
 }

--- a/Library/Services/INfieldSurveyLandingPageService.cs
+++ b/Library/Services/INfieldSurveyLandingPageService.cs
@@ -42,5 +42,13 @@ namespace Nfield.Services
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="T:System.AggregateException"></exception>
         Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string fileName, Stream content);
+
+        /// <summary>
+        /// Exports the landing page of a specific survey.
+        /// </summary>
+        /// <param name="surveyId">The ID of the survey.</param>
+        /// <returns>The status and download URL of the exported landing page.</returns>
+        /// <exception cref="T:System.AggregateException"></exception>
+        Task<SurveyLandingPageExportStatusResponseModel> ExportLandingPageAsync(string surveyId);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -89,6 +89,11 @@ namespace Nfield.Services.Implementation
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
 
             var response = await Client.GetAsync(LandingPageApi(surveyId)).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Failed to export landing page. Status code: {response.StatusCode}, Reason: {response.ReasonPhrase}");
+            }
             var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<SurveyLandingPageExportStatusResponseModel>(responseString);

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -121,6 +121,12 @@ namespace Nfield.Services.Implementation
 
         private async Task<SurveyLandingPageUploadStatusResponseModel> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
+
+            if (content.CanSeek)
+            {
+                content.Seek(0, SeekOrigin.Begin);
+            }
+
             using (var formData = new MultipartFormDataContent())
             {
                 var fileContent = new StreamContent(content);

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -78,6 +78,22 @@ namespace Nfield.Services.Implementation
             return await DoUploadLandingPageAsync(surveyId, fileName, content).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Exports the landing page for a specific survey.
+        /// </summary>
+        /// <param name="surveyId">The ID of the survey.</param>
+        /// <returns>The export status and download URL.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public async Task<SurveyLandingPageExportStatusResponseModel> ExportLandingPageAsync(string surveyId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+
+            var response = await Client.GetAsync(LandingPageApi(surveyId)).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<SurveyLandingPageExportStatusResponseModel>(responseString);
+        }
+
         #endregion
 
         #region Implementation of INfieldConnectionClientObject
@@ -114,11 +130,11 @@ namespace Nfield.Services.Implementation
 
                 var response = await Client.PostAsync(LandingPageApi(surveyId), formData).ConfigureAwait(false);
                 var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var uploadStatus = JsonConvert.DeserializeObject<SurveyLandingPageUploadStatusResponseModel>(responseString);
+                var result = JsonConvert.DeserializeObject<SurveyLandingPageUploadStatusResponseModel>(responseString);
 
-                await ConnectionClient.GetActivityResultAsync<string>(uploadStatus.ActivityId, "Status").ConfigureAwait(false);
+                await ConnectionClient.GetActivityResultAsync<string>(result.ActivityId, "Status").ConfigureAwait(false);
 
-                return uploadStatus;
+                return result;
             }
         }
 

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -121,12 +121,6 @@ namespace Nfield.Services.Implementation
 
         private async Task<SurveyLandingPageUploadStatusResponseModel> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
-
-            if (content.CanSeek)
-            {
-                content.Seek(0, SeekOrigin.Begin);
-            }
-
             using (var formData = new MultipartFormDataContent())
             {
                 var fileContent = new StreamContent(content);

--- a/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
+++ b/Library/Services/Implementation/NfieldSurveyLandingPageService.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
-using Nfield.Models.NipoSoftware.Nfield.Manager.Api.Models;
 using Nfield.Utilities;
 using System;
 using System.IO;
@@ -43,7 +42,7 @@ namespace Nfield.Services.Implementation
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="FileNotFoundException">In case that the file does not exist</exception>
         /// <exception cref="T:System.AggregateException"></exception>
-        public async Task<string> UploadLandingPageAsync(string surveyId, string filePath)
+        public async Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string filePath)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
             Ensure.ArgumentNotNullOrEmptyString(filePath, nameof(filePath));
@@ -70,7 +69,7 @@ namespace Nfield.Services.Implementation
         /// <returns>The activity ID of the upload operation.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="T:System.AggregateException"></exception>
-        public async Task<string> UploadLandingPageAsync(string surveyId, string fileName, Stream content)
+        public async Task<SurveyLandingPageUploadStatusResponseModel> UploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
             Ensure.ArgumentNotNullOrEmptyString(fileName, nameof(fileName));
@@ -104,7 +103,7 @@ namespace Nfield.Services.Implementation
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/landingPage/");
         }
 
-        private async Task<string> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
+        private async Task<SurveyLandingPageUploadStatusResponseModel> DoUploadLandingPageAsync(string surveyId, string fileName, Stream content)
         {
             using (var formData = new MultipartFormDataContent())
             {
@@ -119,7 +118,7 @@ namespace Nfield.Services.Implementation
 
                 await ConnectionClient.GetActivityResultAsync<string>(uploadStatus.ActivityId, "Status").ConfigureAwait(false);
 
-                return uploadStatus.ActivityId;
+                return uploadStatus;
             }
         }
 

--- a/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
+++ b/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
@@ -1,0 +1,107 @@
+//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    public class NfieldSurveyLandingPageServiceTests : NfieldServiceTestsBase
+    {
+        #region UploadLandingPageAsync from file path
+
+        [Fact]
+        public void UploadLandingPageAsync_FileDoesNotExist_ThrowsFileNotFoundException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            var ex = Assert.ThrowsAsync<FileNotFoundException>(() =>
+                target.UploadLandingPageAsync("surveyId", "nonexistent.zip"));
+
+            Assert.Contains("does not exist", ex.Result.Message);
+        }
+
+        [Fact]
+        public void UploadLandingPageAsync_FilePathIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                target.UploadLandingPageAsync("surveyId", null));
+        }
+
+        #endregion
+
+        #region UploadLandingPageAsync with stream
+
+        [Fact]
+        public void UploadLandingPageAsync_StreamIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(new Mock<INfieldConnectionClient>().Object);
+
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                target.UploadLandingPageAsync("surveyId", "landingPage.zip", null));
+        }
+
+        [Fact]
+        public async Task UploadLandingPageAsync_DoesNotThrow()
+        {
+            const string surveyId = "SurveyId";
+            const string fileName = "MyLandingPage.zip";
+            byte[] content = new byte[] { 1, 2, 3, 4, 5 };
+
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            var response = new StringContent(JsonConvert.SerializeObject(new { ActivityId = "activityId" }));
+
+            mockedHttpClient
+                .Setup(client => client.PostAsync(new Uri(ServiceAddress, $"Surveys/{surveyId}/landingPage/"),
+                        It.IsAny<HttpContent>()))
+                .Returns(CreateTask(HttpStatusCode.OK, response));
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(It.IsAny<Uri>()))
+                .Returns(Task.Factory.StartNew(
+                    () =>
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(new
+                        {
+                            ActivityId = "activityId",
+                            Status = 2 // Succeeded
+                        }))
+                    }))
+                .Verifiable();
+
+            var target = new NfieldSurveyLandingPageService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var stream = new MemoryStream(content);
+            await target.UploadLandingPageAsync(surveyId, fileName, stream);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
+++ b/Tests/Services/NfieldSurveyLandingPageServiceTests.cs
@@ -141,7 +141,7 @@ namespace Nfield.Services
         }
 
         [Fact]
-        public async Task ExportLandingPageAsync_InvalidSurveyId_ReturnsErrorStatus()
+        public async Task ExportLandingPageAsync_InvalidSurveyId_ThrowsHttpRequestException()
         {
             // Arrange
             const string invalidSurveyId = "invalidSurveyId";
@@ -156,19 +156,18 @@ namespace Nfield.Services
 
             mockedHttpClient
                 .Setup(client => client.GetAsync(new Uri(ServiceAddress, $"Surveys/{invalidSurveyId}/landingPage/")))
-                .Returns(Task.Factory.StartNew(() =>
-                    new HttpResponseMessage(HttpStatusCode.NotFound) { Content = response }))
-                .Verifiable();
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = response });
 
             var target = new NfieldSurveyLandingPageService();
             target.InitializeNfieldConnection(mockedNfieldConnection.Object);
 
-            // Act
-            var result = await target.ExportLandingPageAsync(invalidSurveyId);
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+                target.ExportLandingPageAsync(invalidSurveyId));
 
-            // Assert
-            Assert.Equal("Failed", result.Status);
+            Assert.Contains("Failed to export landing page", exception.Message);
         }
+
 
 
         #endregion

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.10.{buildId}{suffix}
+3.92.{buildId}{suffix}

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.91.{buildId}{suffix}
+3.10.{buildId}{suffix}


### PR DESCRIPTION
[#AB168352](https://dev.azure.com/niposoftware/Nfield/_workitems/edit/168352)

This pull request introduces the ExportLandingPageAsync method to the NfieldSurveyLandingPageService, enabling users to programmatically export the landing page ZIP file for a given survey.

Summary of changes:

- Added ExportLandingPageAsync(string surveyId) to NfieldSurveyLandingPageService
- Introduced SurveyLandingPageExportStatusResponseModel to handle export response data
- Registered the landing page service in the SDK
- Added unit tests to validate both successful and failure scenarios for export/import